### PR TITLE
Update k8s_deployment_databases.yaml

### DIFF
--- a/k8s_deployment_databases.yaml
+++ b/k8s_deployment_databases.yaml
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
         - name: LLM-mongo-db
-          image: postgres:13.4-alpine
+          image: mongo:7.0.4
           ports:
             - containerPort: 27017
           resources:


### PR DESCRIPTION
MongoDB deployment uses a postgres image.

Maybe use the mongo:7.0.4 image instead?